### PR TITLE
Remove inactive users from DOWNSTREAM_OWNERS

### DIFF
--- a/DOWNSTREAM_OWNERS
+++ b/DOWNSTREAM_OWNERS
@@ -1,17 +1,12 @@
 approvers:
   - jwmatthews
   - sseago
-  - jmontleon
   - shawn-hurley
-  - rayfordj
   - dymurray
   - shubham-pampattiwar
   - kaovilai
-  - eemcmullan
-  - savitharaghunathan
 reviewers:
   - sseago
   - shubham-pampattiwar
   - kaovilai
-  - eemcmullan
-  - savitharaghunathan
+


### PR DESCRIPTION
Remove inactive users from DOWNSTREAM_OWNERS approvers/reviewers.

Replaces #71, which was created against the wrong fork repo (GitHub's owner:branch head shorthand resolved to the openshift_velero-plugin-for-aws fork instead of this repo's fork, due to a shared fork network + identical branch names).

---
@kaovilai requested in [Slack thread](https://redhat-internal.slack.com/archives/C0BHTAWB542/p1785509108887839)